### PR TITLE
update license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,6 @@
 ### License
 Mapbox ADAS Evaluation Kit
 
-Copyright ©2022 Mapbox
+Copyright © 2022 - 2023 Mapbox, Inc. All rights reserved.
 
-All rights reserved.
-
-Mapbox ADAS Evaluation Kit (“Mapbox ADAS Evaluation Kit“) or higher must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox ADAS Evaluation Kit. Developers may modify the Mapbox ADAS Evaluation Kit code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and data collection. The Mapbox Navigation Android SDK sends limited de-identified location and usage data, which Mapbox uses in accordance with the Mapbox Data Processing Addendum. This license terminates automatically if a user no longer has an active Mapbox account.
-
-For the full license terms of Mapbox Navigation Android SDK please consult https://github.com/mapbox/mapbox-navigation-android/blob/main/LICENSE.md
-For the full license terms, please see the Mapbox Terms of Service at https://www.mapbox.com/legal/tos/
+The software and files in this repository (collectively, “Software”) are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-01]


### PR DESCRIPTION
License needs to be updated to reflect the latest version of the Mapbox TOS license text.